### PR TITLE
Added string field in StopReconstruction.srv response

### DIFF
--- a/industrial_reconstruction/industrial_reconstruction/industrial_reconstruction.py
+++ b/industrial_reconstruction/industrial_reconstruction/industrial_reconstruction.py
@@ -234,6 +234,7 @@ class IndustrialReconstruction(Node):
         self.get_logger().info("Generating mesh")
         if self.tsdf_volume is None:
             res.success = False
+            res.message = "Start reconstruction hasn't been called yet"
             return res
         if not self.live_integration:
             while len(self.tsdf_integration_data) > 0:

--- a/industrial_reconstruction/industrial_reconstruction/industrial_reconstruction.py
+++ b/industrial_reconstruction/industrial_reconstruction/industrial_reconstruction.py
@@ -222,6 +222,7 @@ class IndustrialReconstruction(Node):
         self.record = True
 
         res.success = True
+        res.message = "TSDF Volume generated"
         return res
 
     def stopReconstructionCallback(self, req, res):
@@ -279,6 +280,7 @@ class IndustrialReconstruction(Node):
 
         self.get_logger().info("DONE")
         res.success = True
+        res.message = "The mesh was saved to " + str(archive_mesh_filepath)
         return res
 
     def cameraCallback(self, depth_image_msg, rgb_image_msg):

--- a/industrial_reconstruction/industrial_reconstruction/industrial_reconstruction.py
+++ b/industrial_reconstruction/industrial_reconstruction/industrial_reconstruction.py
@@ -222,7 +222,6 @@ class IndustrialReconstruction(Node):
         self.record = True
 
         res.success = True
-        res.message = "TSDF Volume generated"
         return res
 
     def stopReconstructionCallback(self, req, res):
@@ -280,7 +279,7 @@ class IndustrialReconstruction(Node):
 
         self.get_logger().info("DONE")
         res.success = True
-        res.message = "The mesh was saved to " + str(archive_mesh_filepath)
+        res.message = "Mesh Saved to " + req.mesh_filepath
         return res
 
     def cameraCallback(self, depth_image_msg, rgb_image_msg):

--- a/industrial_reconstruction_msgs/srv/StopReconstruction.srv
+++ b/industrial_reconstruction_msgs/srv/StopReconstruction.srv
@@ -9,3 +9,4 @@ uint32 min_num_faces
 industrial_reconstruction_msgs/NormalFilterParams[] normal_filters
 ---
 bool success
+string message


### PR DESCRIPTION
Allows the user to supply information about why the service failed if the success response field is false. 