### PR TITLE
Changed Open3D dependency to not use pip

### DIFF
--- a/industrial_reconstruction/package.xml
+++ b/industrial_reconstruction/package.xml
@@ -22,7 +22,7 @@
   <exec_depend>tf2_msgs</exec_depend>
   <exec_depend>message_filters</exec_depend>
   <exec_depend>visualization_msgs</exec_depend>
-  <exec_depend>python3-open3d-pip</exec_depend>
+  <exec_depend>python3-open3d</exec_depend>
 
   <export>
     <build_type>ament_python</build_type>


### PR DESCRIPTION
Using `pip` to install `open3d` causes issues on ROS Humble for me because the `pip` version of Open3d (currently 0.18.0) generally causes `numpy` 2.0+ to also be installed, which then breaks some other system packages (e.g., `cv2`) and ROS packages (e.g., `cv_bridge`) installed via `apt`.

The easiest solution to this problem appears to be to install the `apt` distributed versions of `open3d` and `numpy` (0.14.1 
 and 1.21.5, respectively, for Ubuntu Jammy)