### PR TITLE
Colorize a mesh with no colors using z-based grayscale

### DIFF
--- a/industrial_reconstruction/src/industrial_reconstruction/utility/ros.py
+++ b/industrial_reconstruction/src/industrial_reconstruction/utility/ros.py
@@ -51,7 +51,16 @@ def transformStampedToVectors(gm_tf_stamped):
 def meshToRos(mesh):
     triangles = np.asarray(mesh.triangles)
     vertices = np.asarray(mesh.vertices)
-    vertex_colors = np.asarray(mesh.vertex_colors)
+    # Check if vertex_colors exist
+    if hasattr(mesh, 'vertex_colors') and len(mesh.vertex_colors) > 0:
+        vertex_colors = np.asarray(mesh.vertex_colors)
+    else:
+        # Assign color based on Z value of the vertex (or any other axis)
+        z_min, z_max = vertices[:, 2].min(), vertices[:, 2].max()
+        vertex_colors = np.zeros_like(vertices)
+        vertex_colors[:, 0] = (vertices[:, 2] - z_min) / (z_max - z_min)
+        vertex_colors[:, 1] = (vertices[:, 2] - z_min) / (z_max - z_min)
+        vertex_colors[:, 2] = (vertices[:, 2] - z_min) / (z_max - z_min)
     out_msg = Marker()
     out_msg.type = out_msg.TRIANGLE_LIST
     out_msg.action = out_msg.ADD


### PR DESCRIPTION
In the SNP application we use the `meshToRos` method to load in a user specified mesh. If there wasn't a color channel in the mesh then this method wouldn't work. This checks for the color field and if it is missing it applies a grayscale coloring based on the z value of the mesh. The grayscale is to make the details visible in RVIZ.