### PR TITLE
Remove visualization message timestamp

### DIFF
--- a/industrial_reconstruction/industrial_reconstruction/industrial_reconstruction.py
+++ b/industrial_reconstruction/industrial_reconstruction/industrial_reconstruction.py
@@ -284,7 +284,6 @@ class IndustrialReconstruction(Node):
 
         o3d.io.write_triangle_mesh(req.mesh_filepath, cropped_mesh, False, True)
         mesh_msg = meshToRos(cropped_mesh)
-        mesh_msg.header.stamp = self.get_clock().now().to_msg()
         mesh_msg.header.frame_id = self.relative_frame
         self.mesh_pub.publish(mesh_msg)
         self.get_logger().info("Mesh Saved to " + req.mesh_filepath)


### PR DESCRIPTION
This PR removes the time stamp from the published mesh visualization message such that it can remain visible and persistent in Rviz for a long period of time when its display is toggled off and on. Otherwise, when the display is toggled off and then back on after a while, the Rviz TF buffer generally is not large enough to perform a lookup at the time in the past when the mesh was published.